### PR TITLE
add "Enable Equalizer" menu group toggle

### DIFF
--- a/equalizer/ConfDialog.py
+++ b/equalizer/ConfDialog.py
@@ -139,9 +139,10 @@ class ConfDialog(object):
             action_name='Equalize', label=_('_Equalizer'),
             action_type='app')
 
-        action_group.add_action(func=self.toggle_enabled,
+        action_group.add_action_with_accel(func=self.toggle_enabled,
             action_name='equalizer-enabled', label=_("E_nable Equalizer"),
             action_type='app',
+            accel='<ctrl>e',
             action_value=self.conf.enabled,
             action_state = ActionGroup.TOGGLE)
 

--- a/equalizer/ConfDialog.py
+++ b/equalizer/ConfDialog.py
@@ -28,6 +28,7 @@ ui_string="""
     <menu name="ControlMenu" action="Control"> 
       <placeholder name="PluginPlaceholder">
         <menuitem name="Equalizer" action="Equalize"/>
+        <menuitem name="Enable Equalizer" action="equalizer-enabled"/>
       </placeholder>
     </menu>
   </menubar>
@@ -133,14 +134,25 @@ class ConfDialog(object):
 
     def add_ui(self, shell):
         action_group = ActionGroup(shell, 'EqualizerActionGroup')
+
         action_group.add_action(func=self.show_ui,
             action_name='Equalize', label=_('_Equalizer'),
             action_type='app')
+
+        action_group.add_action(func=self.toggle_enabled,
+            action_name='equalizer-enabled', label=_("E_nable Equalizer"),
+            action_type='app',
+            action_value=self.conf.enabled,
+            action_state = ActionGroup.TOGGLE)
 
         self._appshell = ApplicationShell(shell)
         self._appshell.insert_action_group(action_group)
         self._appshell.add_app_menuitems(ui_string, 'EqualizerActionGroup')
         
+    def toggle_enabled(self, *args):
+        enabled = not self.conf.enabled
+        self.conf.change_enabled(enabled, self.eq)
+
     def show_ui(self, *args):
         self.read_presets()
         self.get_dialog().present()

--- a/equalizer/equalizer_rb3compat.py
+++ b/equalizer/equalizer_rb3compat.py
@@ -500,7 +500,7 @@ class ActionGroup(object):
                 self.actiongroup.add_action(action)
 
             if accel:
-                app.add_accelerator(accel, action_type+"."+action_name, None)
+                app.set_accels_for_action(action_type+"."+action_name, [accel])
         else:
             if 'stock_id' in args:
                 stock_id = args['stock_id']

--- a/equalizer/equalizer_rb3compat.py
+++ b/equalizer/equalizer_rb3compat.py
@@ -461,6 +461,7 @@ class ActionGroup(object):
         key value of "action_type" is the RB2.99 Gio.Action type ("win" or "app")
            by default it assumes all actions are "win" type
         key value of "action_state" determines what action state to create
+        key value of "action_value" determines initial action value for the TOGGLE type
         '''
         if 'label' in args:
             label = args['label']
@@ -475,11 +476,13 @@ class ActionGroup(object):
         state = ActionGroup.STANDARD            
         if 'action_state' in args:
             state = args['action_state']
+
+        action_value = args.get('action_value', False)
         
         if is_rb3(self.shell):
             if state == ActionGroup.TOGGLE:
                 action = Gio.SimpleAction.new_stateful(action_name, None,
-                                               GLib.Variant('b', False))
+                                               GLib.Variant('b', action_value))
             else:
                 action = Gio.SimpleAction.new(action_name, None)
 
@@ -508,6 +511,7 @@ class ActionGroup(object):
                 action = Gtk.ToggleAction(label=label,
                     name=action_name,
                    tooltip='', stock_id=stock_id)
+                action.set_active(action_value)
             else:
                 action = Gtk.Action(label=label,
                     name=action_name,


### PR DESCRIPTION
This allows easy enable / disable from the app menu.

Enable / disable state is not reflected in the dialog, and you can't enable / disable from the dialog either. But I think it's useful to enable / disable without having to go via the dialog.

I haven't tested the rhythmbox 2 code path modifications, I just based it on the documentation.

![screenshot from 2016-04-02 15-58-45](https://cloud.githubusercontent.com/assets/14172/14224552/0bdb2216-f8ec-11e5-8020-0672ad73fa2a.png)
