### PR TITLE
Fixes for gnome 3.24 and recent GST contracts

### DIFF
--- a/equalizer/Conf.py
+++ b/equalizer/Conf.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
+import gi
+gi.require_version('GConf', '2.0')
 from gi.repository import GConf, Gst
 
 EQUALIZER_GCONF_PREFIX = '/apps/rhythmbox/plugins/equalizer'

--- a/equalizer/equalizer.py
+++ b/equalizer/equalizer.py
@@ -19,7 +19,6 @@ from ConfDialog import ConfDialog
 import Conf
 
 import os
-
 from gi.repository import GObject, Gst, Peas
 from gi.repository import RB
 
@@ -35,6 +34,7 @@ class EqualizerPlugin(GObject.Object, Peas.Activatable):
 		self.sp = self.shell.props.shell_player
 		
 		self.conf = Conf.Config()
+		Gst.init(None)
 		self.eq = Gst.ElementFactory.make('equalizer-10bands', None)
 		self.conf.apply_settings(self.eq)
 		


### PR DESCRIPTION
The plugin doesn't load in gnome 3.24 due to GST in not initialized. And also there is warning about not choosing the correct GConf version with a require_version. This pull request has fixed both the warning and the error which cause the plugin to not load. 